### PR TITLE
Fix build with dcmtk 3.6.5

### DIFF
--- a/cadxcore/main/controllers/dcmtk/libi2d/d2dcommon.h
+++ b/cadxcore/main/controllers/dcmtk/libi2d/d2dcommon.h
@@ -23,6 +23,7 @@
 
 
 #include <dcmtk/dcmdata/dctk.h>
+#include <dcmtk/ofstd/ofconsol.h>
 class D2DCommon
 {
 public:


### PR DESCRIPTION
```
cd /<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/cadxcore && /usr/bin/c++ -DAPIEXPORT -DCURL_STATICLIB -DDCMTK_POST_20170228 -DGINKGO_ARCH_x86_64 -DGINKGO_CODENAME=\"\" -DGINKGO_VERSION=\"3.8.8\" -DHAVE_CONFIG_H -DINTERNET_DIST -DITK_IO_FACTORY_REGISTER_MANAGER -DLINUX -DMONOLITIC -DUSE_SYSTEM_SQLITE -DUSING_EXTENSIONS -DWXUSINGDLL -D_FILE_OFFSET_BITS=64 -D__WXGTK__ -DvtkIOGeometry_AUTOINIT="1(vtkIOMPIParallel)" -DvtkIOImage_AUTOINIT="1(vtkIOMPIImage)" -DvtkIOParallel_AUTOINIT="1(vtkIOMPIParallel)" -DvtkRenderingContext2D_AUTOINIT="1(vtkRenderingContextOpenGL)" -DvtkRenderingCore_AUTOINIT="3(vtkInteractionStyle,vtkRenderingFreeType,vtkRenderingOpenGL)" -DvtkRenderingVolume_AUTOINIT="1(vtkRenderingVolumeOpenGL)" -I/<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/cadxcore/ITKFactoryRegistration -I/usr/include/cairo -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/pixman-1 -I/usr/include/uuid -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/gtk-3.0 -I/usr/include/at-spi2-atk/2.0 -I/usr/include/at-spi-2.0 -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -I/usr/include/gio-unix-2.0 -I/usr/include/pango-1.0 -I/usr/include/fribidi -I/usr/include/harfbuzz -I/usr/include/atk-1.0 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/libmount -I/usr/include/blkid -I/<<PKGBUILDDIR>>/cadxcore/CADxCore -I/<<PKGBUILDDIR>>/cadxcore -I/<<PKGBUILDDIR>>/cadxcore/vtk -I/<<PKGBUILDDIR>>/cadxcore/itk -I/<<PKGBUILDDIR>>/cadxcore/wx -I/<<PKGBUILDDIR>>/cadxcore/wx/VTK -I/<<PKGBUILDDIR>>/cadxcore/VTKInria3D -I/<<PKGBUILDDIR>>/cadxcore/VTKInria3D/wxVTK -I/usr/include/jsoncpp -I/<<PKGBUILDDIR>>/../lib/Linux-x86_64/libcurl-7.28.1/include -I/usr/lib/x86_64-linux-gnu/wx/include/gtk3-unicode-3.0 -I/usr/include/wx-3.0 -I/usr/include/vtk-6.3 -I/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi -I/usr/lib/x86_64-linux-gnu/openmpi/include -I/usr/include/hdf5/openmpi -I/usr/include/libxml2 -isystem /usr/include/gdcm-3.0 -isystem /usr/include/ITK-4.13 -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -DNDEBUG -fPIC   -o CMakeFiles/CADxCore.dir/main/controllers/pacscontroller.cpp.o -c /<<PKGBUILDDIR>>/cadxcore/main/controllers/pacscontroller.cpp
In file included from /<<PKGBUILDDIR>>/cadxcore/main/controllers/dcmtk/libi2d/document2dcm.h:28,
                 from /<<PKGBUILDDIR>>/cadxcore/main/controllers/dcmtk/dicomimg2dcm.h:29,
                 from /<<PKGBUILDDIR>>/cadxcore/main/controllers/pacscontroller.cpp:22:
/<<PKGBUILDDIR>>/cadxcore/main/controllers/dcmtk/libi2d/d2dcommon.h:40:27: error: ‘OFConsole’ has not been declared
   40 |         void printMessage(OFConsole *stream,
      |                           ^~~~~~~~~
/<<PKGBUILDDIR>>/cadxcore/main/controllers/dcmtk/libi2d/d2dcommon.h:55:27: error: ‘OFConsole’ has not been declared
   55 |         void setLogStream(OFConsole *stream)
      |                           ^~~~~~~~~
/<<PKGBUILDDIR>>/cadxcore/main/controllers/dcmtk/libi2d/d2dcommon.h:96:9: error: ‘OFConsole’ does not name a type; did you mean ‘ofConsole’?
   96 |         OFConsole *m_logStream;
      |         ^~~~~~~~~
      |         ofConsole

```
Please see the corresponding Debian bug report for details on the failure
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=974660